### PR TITLE
feat: 引っ張りUIの実装

### DIFF
--- a/Assets/Scripts/Components/PullArrowUI.cs
+++ b/Assets/Scripts/Components/PullArrowUI.cs
@@ -1,0 +1,81 @@
+using UnityEngine;
+using WhatTheStrike.Domain.Services;
+
+namespace WhatTheStrike.Components
+{
+    /// <summary>
+    /// 引っ張りUIコンポーネント
+    /// Shootableを起点としてドラッグ方向と逆向きに矢印を表示する
+    /// </summary>
+    public class PullArrowUI : MonoBehaviour
+    {
+        [Header("矢印設定")]
+        [SerializeField] private SpriteRenderer? arrowSprite;
+        [SerializeField] private float baseLength = 1f;
+        [SerializeField] private float lengthMultiplier = 2f;
+
+        // 表示対象のShootable
+        private Shootable? _targetShootable;
+        private bool _isVisible = false;
+
+        private void Awake()
+        {
+            Hide();
+        }
+
+        /// <summary>
+        /// 矢印UIを表示する
+        /// </summary>
+        public void Show(Shootable target)
+        {
+            _targetShootable = target;
+            _isVisible = true;
+
+            if (arrowSprite != null)
+            {
+                arrowSprite.enabled = true;
+            }
+        }
+
+        /// <summary>
+        /// 矢印UIを非表示にする
+        /// </summary>
+        public void Hide()
+        {
+            _isVisible = false;
+            _targetShootable = null;
+
+            if (arrowSprite != null)
+            {
+                arrowSprite.enabled = false;
+            }
+        }
+
+        /// <summary>
+        /// 矢印UIを更新する
+        /// </summary>
+        /// <param name="direction">発射方向（ドラッグ方向の逆）</param>
+        /// <param name="pullDistance">引っ張り距離（0〜MaxPullDistance）</param>
+        public void UpdateArrow(Vector2 direction, float pullDistance)
+        {
+            if (!_isVisible || _targetShootable == null || arrowSprite == null)
+            {
+                return;
+            }
+
+            // 矢印の位置をShootableの位置に設定
+            transform.position = _targetShootable.transform.position;
+
+            // 発射方向に向けて回転（Z軸回転）
+            float angle = Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
+            transform.rotation = Quaternion.Euler(0, 0, angle);
+
+            // 引っ張り距離に応じて矢印を伸ばす
+            float normalizedPull = pullDistance / ShotCalculator.MaxPullDistance;
+            float arrowLength = baseLength + normalizedPull * lengthMultiplier;
+
+            // X軸方向にスケール（矢印が右向きを想定）
+            transform.localScale = new Vector3(arrowLength, 1f, 1f);
+        }
+    }
+}

--- a/Assets/Scripts/Components/PullArrowUI.cs.meta
+++ b/Assets/Scripts/Components/PullArrowUI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e26e59ecb049ecf40a8725c0de7139fc

--- a/Assets/Scripts/Core/TurnController.cs
+++ b/Assets/Scripts/Core/TurnController.cs
@@ -14,6 +14,7 @@ namespace WhatTheStrike.Core
         [Header("設定")]
         [SerializeField] private float maxPullDistance = 3f;
         [SerializeField] private LineRenderer? trajectoryLine;
+        [SerializeField] private PullArrowUI? pullArrowUI;
 
         // 状態
         private List<Shootable> _shootables = new();
@@ -80,6 +81,7 @@ namespace WhatTheStrike.Core
                 {
                     _isDragging = true;
                     _dragStartPos = current.transform.position;
+                    ShowPullArrow(current);
                 }
             }
 
@@ -95,6 +97,7 @@ namespace WhatTheStrike.Core
                 _isDragging = false;
                 ExecuteShot(current);
                 HideTrajectory();
+                HidePullArrow();
             }
         }
 
@@ -142,6 +145,9 @@ namespace WhatTheStrike.Core
             trajectoryLine.positionCount = 2;
             trajectoryLine.SetPosition(0, current.transform.position);
             trajectoryLine.SetPosition(1, (Vector2)current.transform.position + direction * pullDistance * 2);
+
+            // 引っ張りUIも更新
+            UpdatePullArrow(direction, pullDistance);
         }
 
         /// <summary>
@@ -152,6 +158,39 @@ namespace WhatTheStrike.Core
             if (trajectoryLine != null)
             {
                 trajectoryLine.enabled = false;
+            }
+        }
+
+        /// <summary>
+        /// 引っ張りUIを表示
+        /// </summary>
+        private void ShowPullArrow(Shootable shootable)
+        {
+            if (pullArrowUI != null)
+            {
+                pullArrowUI.Show(shootable);
+            }
+        }
+
+        /// <summary>
+        /// 引っ張りUIを更新
+        /// </summary>
+        private void UpdatePullArrow(Vector2 direction, float pullDistance)
+        {
+            if (pullArrowUI != null)
+            {
+                pullArrowUI.UpdateArrow(direction, pullDistance);
+            }
+        }
+
+        /// <summary>
+        /// 引っ張りUIを非表示
+        /// </summary>
+        private void HidePullArrow()
+        {
+            if (pullArrowUI != null)
+            {
+                pullArrowUI.Hide();
             }
         }
 


### PR DESCRIPTION
## 概要
Issue #2 の引っ張りUI機能を実装しました。

画面をタップしてドラッグすると、Shootableを起点としてドラッグ方向と逆向きに矢印UIが表示されます。

## 関連Issue
Closes #2

## 変更点
- `PullArrowUI`コンポーネントを新規作成（`Assets/Scripts/Components/PullArrowUI.cs`）
  - SpriteRendererを使用して3D空間上に矢印を表示
  - 引っ張り距離に応じて矢印の長さが変化
  - 発射方向（ドラッグ方向の逆）に向けて回転
- `TurnController`に引っ張りUIとの連携を追加
  - ドラッグ開始時にUIを表示
  - ドラッグ中にUIを更新
  - リリース時にUIを非表示

## セットアップ方法
1. 矢印用のSprite画像を用意（右向きの矢印を推奨）
2. 空のGameObjectを作成し、`PullArrowUI`コンポーネントをアタッチ
3. 子オブジェクトに`SpriteRenderer`を持つGameObjectを配置
4. `PullArrowUI`の`arrowSprite`フィールドに上記SpriteRendererをアサイン
5. `TurnController`の`pullArrowUI`フィールドにPullArrowUIをアサイン

## テスト確認項目
- [ ] ドラッグ開始時に矢印UIが表示される
- [ ] ドラッグ方向と逆向きに矢印が向く
- [ ] 引っ張り距離に応じて矢印の長さが変化する
- [ ] リリース時に矢印UIが非表示になる
- [ ] Shootableが移動中は矢印UIが表示されない

---
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual pull arrow indicator that appears during drag interactions, displaying the pull direction and intensity for enhanced gameplay feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->