### PR TITLE
feat: ワープギミックのShootable対応

### DIFF
--- a/Assets/Scripts/Gimmicks/WarpGimmick.cs
+++ b/Assets/Scripts/Gimmicks/WarpGimmick.cs
@@ -1,0 +1,111 @@
+using UnityEngine;
+using WhatTheStrike.Components;
+
+namespace WhatTheStrike.Gimmicks
+{
+    /// <summary>
+    /// ワープギミック
+    /// Shootableが入ると出口位置にテレポートする
+    /// 自身もShootableコンポーネントを付けることで発射可能
+    /// NOTE: Shootableコンポーネントを付けるとターン順に含まれる
+    /// </summary>
+    [RequireComponent(typeof(Collider2D))]
+    public class WarpGimmick : MonoBehaviour
+    {
+        [Header("ワープ設定")]
+        [SerializeField] private Transform? exitPoint;
+        [SerializeField] private bool preserveVelocity = true;
+
+        [Header("移動中のワープ機能")]
+        [SerializeField] private bool disableWarpWhileMoving = true;
+
+        private Shootable? _shootableComponent;
+        private bool _isActive = true;
+
+        public bool IsActive => _isActive;
+        public Transform? ExitPoint => exitPoint;
+
+        private void Awake()
+        {
+            _shootableComponent = GetComponent<Shootable>();
+        }
+
+        /// <summary>
+        /// ワープ機能が現在有効かどうか
+        /// 自身がMoving状態の場合は無効
+        /// </summary>
+        private bool IsWarpFunctional
+        {
+            get
+            {
+                if (!_isActive) return false;
+                if (disableWarpWhileMoving && _shootableComponent != null)
+                {
+                    return _shootableComponent.State != ShootableState.Moving;
+                }
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// ワープの有効/無効を切り替え
+        /// </summary>
+        public void SetActive(bool active)
+        {
+            _isActive = active;
+        }
+
+        /// <summary>
+        /// 出口位置を設定
+        /// </summary>
+        public void SetExitPoint(Transform exit)
+        {
+            exitPoint = exit;
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (!IsWarpFunctional) return;
+            if (exitPoint == null) return;
+
+            var shootable = other.GetComponent<Shootable>();
+            if (shootable == null) return;
+
+            // 自分自身（Shootableとしての自分）がワープに入った場合は無視
+            if (_shootableComponent != null && shootable == _shootableComponent) return;
+
+            // Moving状態のShootableのみワープ
+            if (shootable.State != ShootableState.Moving) return;
+
+            ExecuteWarp(shootable);
+        }
+
+        /// <summary>
+        /// ワープを実行
+        /// </summary>
+        private void ExecuteWarp(Shootable shootable)
+        {
+            if (exitPoint == null) return;
+
+            var rb = shootable.GetComponent<Rigidbody2D>();
+            if (rb == null) return;
+
+            Vector2 velocity = rb.linearVelocity;
+
+            // 出口位置にテレポート
+            shootable.transform.position = exitPoint.position;
+
+            // 速度を維持または0にリセット
+            if (preserveVelocity)
+            {
+                rb.linearVelocity = velocity;
+            }
+            else
+            {
+                rb.linearVelocity = Vector2.zero;
+            }
+
+            Debug.Log($"Warp: {shootable.name} teleported to {exitPoint.position}");
+        }
+    }
+}

--- a/Assets/Scripts/Gimmicks/WarpGimmick.cs
+++ b/Assets/Scripts/Gimmicks/WarpGimmick.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using UnityEngine;
 using WhatTheStrike.Components;
 
@@ -9,8 +11,7 @@ namespace WhatTheStrike.Gimmicks
     /// 自身もShootableコンポーネントを付けることで発射可能
     /// NOTE: Shootableコンポーネントを付けるとターン順に含まれる
     /// </summary>
-    [RequireComponent(typeof(Collider2D))]
-    public class WarpGimmick : MonoBehaviour
+    public class WarpGimmick : Gimmick
     {
         [Header("ワープ設定")]
         [SerializeField] private Transform? exitPoint;
@@ -20,9 +21,7 @@ namespace WhatTheStrike.Gimmicks
         [SerializeField] private bool disableWarpWhileMoving = true;
 
         private Shootable? _shootableComponent;
-        private bool _isActive = true;
 
-        public bool IsActive => _isActive;
         public Transform? ExitPoint => exitPoint;
 
         private void Awake()
@@ -38,21 +37,13 @@ namespace WhatTheStrike.Gimmicks
         {
             get
             {
-                if (!_isActive) return false;
+                if (!isActive) return false;
                 if (disableWarpWhileMoving && _shootableComponent != null)
                 {
                     return _shootableComponent.State != ShootableState.Moving;
                 }
                 return true;
             }
-        }
-
-        /// <summary>
-        /// ワープの有効/無効を切り替え
-        /// </summary>
-        public void SetActive(bool active)
-        {
-            _isActive = active;
         }
 
         /// <summary>
@@ -63,19 +54,16 @@ namespace WhatTheStrike.Gimmicks
             exitPoint = exit;
         }
 
-        private void OnTriggerEnter2D(Collider2D other)
+        /// <summary>
+        /// Shootableがワープに入った時の処理
+        /// </summary>
+        protected override void OnShootableEnter(Shootable shootable)
         {
             if (!IsWarpFunctional) return;
             if (exitPoint == null) return;
 
-            var shootable = other.GetComponent<Shootable>();
-            if (shootable == null) return;
-
             // 自分自身（Shootableとしての自分）がワープに入った場合は無視
             if (_shootableComponent != null && shootable == _shootableComponent) return;
-
-            // Moving状態のShootableのみワープ
-            if (shootable.State != ShootableState.Moving) return;
 
             ExecuteWarp(shootable);
         }


### PR DESCRIPTION
## 概要
Issue #6の要件に基づき、ワープギミックを実装し、Shootableとして発射できるようにしました。

ワープを発射することで：
- モンスターをショットする前にワープを配置して有利なポジションを作れる
- 邪魔な位置にあるワープを移動させられる

## 関連Issue
Closes #6

## 変更点
- `WarpGimmick`クラスを新規作成（`Assets/Scripts/Gimmicks/WarpGimmick.cs`）
  - 他のShootableが入ると出口位置にテレポート
  - Shootableコンポーネントを付けるとターン順に含まれ発射可能
  - 自身が移動中はワープ機能を無効化（設定可能）

## 使用方法
1. GameObjectにWarpGimmickコンポーネントをアタッチ
2. 出口位置（exitPoint）を設定
3. Shootableとして発射可能にする場合は、同じGameObjectにShootableコンポーネントも追加
4. Rigidbody2D、Collider2D（isTrigger=true）を設定

## テスト確認項目
- [ ] ワープに他のShootableが入るとテレポートする
- [ ] ワープにShootableコンポーネントを付けるとターン順に含まれる
- [ ] ワープを引っ張って発射できる
- [ ] ワープ自身が移動中はワープ機能が無効になる
- [ ] ワープが停止するとワープ機能が再び有効になる

---
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WarpGimmick mechanic to teleport eligible objects to designated exit points.
  * Configurable velocity handling to preserve or reset object movement after warp.
  * Optional restriction to prevent warping while an object is moving.
  * Global enable/disable control for the gimmick.
  * Prevents self-warping of the gimmick’s own attached object.
  * External assignment of exit points for flexible level setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->