### PR TITLE
feat: アウトゲーム用ショット可能ボタンを追加

### DIFF
--- a/Assets/Scripts/Components/ShootableButton.cs
+++ b/Assets/Scripts/Components/ShootableButton.cs
@@ -76,6 +76,7 @@ namespace WhatTheStrike.Components
 
             // Shootableの停止イベントを購読
             shootable.OnStopped += OnShootableStopped;
+            _subscribedShootables.Add(shootable);
         }
 
         private void OnTriggerExit2D(Collider2D other)
@@ -85,6 +86,7 @@ namespace WhatTheStrike.Components
 
             // 購読解除
             shootable.OnStopped -= OnShootableStopped;
+            _subscribedShootables.Remove(shootable);
         }
 
         /// <summary>

--- a/Assets/Scripts/Components/ShootableButton.cs
+++ b/Assets/Scripts/Components/ShootableButton.cs
@@ -1,0 +1,117 @@
+#nullable enable
+
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace WhatTheStrike.Components
+{
+    /// <summary>
+    /// アウトゲーム用のショット可能なボタン
+    /// Shootableがこのボタンの範囲内で停止するとイベントが発火する
+    /// </summary>
+    [RequireComponent(typeof(Collider2D))]
+    public class ShootableButton : MonoBehaviour
+    {
+        [Header("ボタン設定")]
+        [SerializeField] private UnityEvent onButtonActivated = new();
+
+        [Header("範囲設定")]
+        [Tooltip("ボタンの有効範囲（Collider2Dを使用する場合はこの値は無視されます）")]
+        [SerializeField] private float activationRadius = 1f;
+        [SerializeField] private bool useColliderAsRange = true;
+
+        private Collider2D? _collider;
+
+        public UnityEvent OnButtonActivated => onButtonActivated;
+
+        private void Awake()
+        {
+            _collider = GetComponent<Collider2D>();
+            if (_collider != null)
+            {
+                _collider.isTrigger = true;
+            }
+        }
+
+        /// <summary>
+        /// Shootableが範囲内で停止したかチェック
+        /// </summary>
+        public bool CheckActivation(Shootable shootable)
+        {
+            if (shootable.State != ShootableState.Stopped) return false;
+
+            if (IsInRange(shootable.transform.position))
+            {
+                ActivateButton();
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// 位置が範囲内かどうか判定
+        /// </summary>
+        private bool IsInRange(Vector2 position)
+        {
+            if (useColliderAsRange && _collider != null)
+            {
+                return _collider.OverlapPoint(position);
+            }
+            return Vector2.Distance(transform.position, position) <= activationRadius;
+        }
+
+        /// <summary>
+        /// ボタンを発火
+        /// </summary>
+        private void ActivateButton()
+        {
+            Debug.Log($"ShootableButton activated: {gameObject.name}");
+            onButtonActivated?.Invoke();
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            var shootable = other.GetComponent<Shootable>();
+            if (shootable == null) return;
+
+            // Shootableの停止イベントを購読
+            shootable.OnStopped += OnShootableStopped;
+        }
+
+        private void OnTriggerExit2D(Collider2D other)
+        {
+            var shootable = other.GetComponent<Shootable>();
+            if (shootable == null) return;
+
+            // 購読解除
+            shootable.OnStopped -= OnShootableStopped;
+        }
+
+        /// <summary>
+        /// Shootableが停止した時の処理
+        /// </summary>
+        private void OnShootableStopped(Shootable shootable)
+        {
+            // 購読解除
+            shootable.OnStopped -= OnShootableStopped;
+
+            // 範囲内で停止したらボタン発火
+            if (IsInRange(shootable.transform.position))
+            {
+                ActivateButton();
+            }
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            // 有効範囲を表示（Colliderを使わない場合のみ）
+            if (!useColliderAsRange)
+            {
+                Gizmos.color = new Color(0, 1, 0, 0.3f);
+                Gizmos.DrawSphere(transform.position, activationRadius);
+                Gizmos.color = Color.green;
+                Gizmos.DrawWireSphere(transform.position, activationRadius);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 概要
Issue #7の要件に基づき、アウトゲーム（メニュー画面など）でShootableをボタンの範囲内に発射して停止させるとイベントが発火する機能を実装しました。

## 関連Issue
Closes #7

## 変更点
- `ShootableButton`コンポーネントを新規作成（`Assets/Scripts/Components/ShootableButton.cs`）
  - Shootableがボタン範囲内で停止するとUnityEventが発火
  - Collider2D（isTrigger）を使用して範囲判定
  - 半径指定での範囲判定もサポート
  - Gizmosで有効範囲を可視化

## 使用方法
1. GameObjectにShootableButtonコンポーネントをアタッチ
2. Collider2Dが自動的にisTriggerに設定される
3. OnButtonActivatedイベントに実行したい処理を登録
   - 例: シーン遷移、メニュー表示など
4. Shootableを発射してボタン範囲内に停止させるとイベント発火

## テスト確認項目
- [ ] Shootableがボタン範囲内で停止するとイベントが発火する
- [ ] Shootableがボタン範囲外で停止してもイベントは発火しない
- [ ] 複数のShootableButtonが配置されている場合、それぞれ独立して動作する
- [ ] OnButtonActivatedに登録した処理が正しく実行される

---
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new in-game button component that activates when shootable objects enter and stop within its detection area.
  * Supports two range detection modes (use collider bounds or a configurable radius) for flexible gameplay.
  * Fires a configurable activation event when triggered and can be invoked programmatically.
  * Includes editor gizmo visualizations and logging to aid setup and debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->