### PR TITLE
feat: アウトゲーム（ステージ選択）システムを追加

### DIFF
--- a/Assets/Scripts/Editor/OutgameSceneBuilder.cs
+++ b/Assets/Scripts/Editor/OutgameSceneBuilder.cs
@@ -1,0 +1,265 @@
+#nullable enable
+
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using WhatTheStrike.Outgame;
+
+namespace WhatTheStrike.Editor
+{
+    /// <summary>
+    /// アウトゲームシーン自動生成
+    /// </summary>
+    public static class OutgameSceneBuilder
+    {
+        [MenuItem("WhatTheStrike/Create Outgame Scene")]
+        public static void CreateOutgameScene()
+        {
+            // 新規シーン作成
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            scene.name = "StageSelect";
+
+            // カメラ設定
+            CreateCamera();
+
+            // 床・壁作成
+            CreateFloorAndWalls();
+
+            // マネージャー作成
+            CreateManagers();
+
+            // プレイヤー作成
+            CreatePlayer();
+
+            // ライト作成
+            CreateLight();
+
+            Debug.Log("アウトゲームシーンを作成しました");
+        }
+
+        private static void CreateCamera()
+        {
+            var cameraObj = new GameObject("Main Camera");
+            cameraObj.tag = "MainCamera";
+            var camera = cameraObj.AddComponent<Camera>();
+            camera.orthographic = false;
+            camera.fieldOfView = 60;
+            camera.clearFlags = CameraClearFlags.SolidColor;
+            camera.backgroundColor = new Color(0.1f, 0.1f, 0.2f);
+            cameraObj.transform.position = new Vector3(0, 15, -5);
+            cameraObj.transform.rotation = Quaternion.Euler(70, 0, 0);
+            cameraObj.AddComponent<AudioListener>();
+        }
+
+        private static void CreateFloorAndWalls()
+        {
+            float worldSize = 10f;
+            float wallHeight = 2f;
+            float wallThickness = 0.5f;
+
+            // 床
+            var floor = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            floor.name = "Floor";
+            floor.transform.position = new Vector3(0, -0.25f, 0);
+            floor.transform.localScale = new Vector3(worldSize, 0.5f, worldSize);
+            var floorRenderer = floor.GetComponent<Renderer>();
+            floorRenderer.material = CreateMaterial(new Color(0.3f, 0.3f, 0.35f));
+
+            // 壁（上）
+            var wallTop = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            wallTop.name = "Wall_Top";
+            wallTop.transform.position = new Vector3(0, wallHeight / 2, worldSize / 2);
+            wallTop.transform.localScale = new Vector3(worldSize + wallThickness * 2, wallHeight, wallThickness);
+            wallTop.GetComponent<Renderer>().material = CreateMaterial(new Color(0.5f, 0.5f, 0.55f));
+
+            // 壁（下）
+            var wallBottom = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            wallBottom.name = "Wall_Bottom";
+            wallBottom.transform.position = new Vector3(0, wallHeight / 2, -worldSize / 2);
+            wallBottom.transform.localScale = new Vector3(worldSize + wallThickness * 2, wallHeight, wallThickness);
+            wallBottom.GetComponent<Renderer>().material = CreateMaterial(new Color(0.5f, 0.5f, 0.55f));
+
+            // 壁（左）
+            var wallLeft = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            wallLeft.name = "Wall_Left";
+            wallLeft.transform.position = new Vector3(-worldSize / 2, wallHeight / 2, 0);
+            wallLeft.transform.localScale = new Vector3(wallThickness, wallHeight, worldSize);
+            wallLeft.GetComponent<Renderer>().material = CreateMaterial(new Color(0.5f, 0.5f, 0.55f));
+
+            // 壁（右）
+            var wallRight = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            wallRight.name = "Wall_Right";
+            wallRight.transform.position = new Vector3(worldSize / 2, wallHeight / 2, 0);
+            wallRight.transform.localScale = new Vector3(wallThickness, wallHeight, worldSize);
+            wallRight.GetComponent<Renderer>().material = CreateMaterial(new Color(0.5f, 0.5f, 0.55f));
+
+            // 壁をグループ化
+            var wallsParent = new GameObject("Walls");
+            wallTop.transform.SetParent(wallsParent.transform);
+            wallBottom.transform.SetParent(wallsParent.transform);
+            wallLeft.transform.SetParent(wallsParent.transform);
+            wallRight.transform.SetParent(wallsParent.transform);
+        }
+
+        private static void CreateManagers()
+        {
+            // Managers親オブジェクト
+            var managersObj = new GameObject("Managers");
+
+            // OutgameManager
+            var outgameManagerObj = new GameObject("OutgameManager");
+            outgameManagerObj.transform.SetParent(managersObj.transform);
+            var outgameManager = outgameManagerObj.AddComponent<OutgameManager>();
+
+            // StageLayoutGenerator
+            var layoutGeneratorObj = new GameObject("StageLayoutGenerator");
+            layoutGeneratorObj.transform.SetParent(managersObj.transform);
+            var layoutGenerator = layoutGeneratorObj.AddComponent<StageLayoutGenerator>();
+
+            // ステージボタンコンテナ
+            var buttonContainer = new GameObject("StageButtons");
+            buttonContainer.transform.SetParent(layoutGeneratorObj.transform);
+
+            // SerializedObjectで参照を設定
+            var outgameSO = new SerializedObject(outgameManager);
+            outgameSO.FindProperty("layoutGenerator").objectReferenceValue = layoutGenerator;
+            outgameSO.ApplyModifiedProperties();
+
+            var layoutSO = new SerializedObject(layoutGenerator);
+            layoutSO.FindProperty("stageButtonContainer").objectReferenceValue = buttonContainer.transform;
+            layoutSO.ApplyModifiedProperties();
+        }
+
+        private static void CreatePlayer()
+        {
+            // プレイヤー球体
+            var playerObj = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            playerObj.name = "Player";
+            playerObj.transform.position = new Vector3(0, 0.5f, -4);
+            playerObj.transform.localScale = new Vector3(0.8f, 0.8f, 0.8f);
+            playerObj.GetComponent<Renderer>().material = CreateMaterial(new Color(0.2f, 0.6f, 1f));
+
+            // Rigidbody設定
+            var rb = playerObj.AddComponent<Rigidbody>();
+            rb.useGravity = false;
+            rb.constraints = RigidbodyConstraints.FreezePositionY | RigidbodyConstraints.FreezeRotation;
+
+            // Shootable3D追加
+            var shootable = playerObj.AddComponent<Shootable3D>();
+
+            // Shot3DController追加
+            var shotController = playerObj.AddComponent<Shot3DController>();
+
+            // 軌道表示用LineRenderer
+            var lineRenderer = playerObj.AddComponent<LineRenderer>();
+            lineRenderer.startWidth = 0.1f;
+            lineRenderer.endWidth = 0.05f;
+            lineRenderer.material = new Material(Shader.Find("Sprites/Default"));
+            lineRenderer.startColor = Color.white;
+            lineRenderer.endColor = new Color(1, 1, 1, 0.3f);
+            lineRenderer.enabled = false;
+
+            // SerializedObjectで参照を設定
+            var controllerSO = new SerializedObject(shotController);
+            controllerSO.FindProperty("shootable").objectReferenceValue = shootable;
+            controllerSO.FindProperty("trajectoryLine").objectReferenceValue = lineRenderer;
+            controllerSO.ApplyModifiedProperties();
+
+            // OutgameManagerに参照を設定
+            var outgameManager = Object.FindFirstObjectByType<OutgameManager>();
+            if (outgameManager != null)
+            {
+                var managerSO = new SerializedObject(outgameManager);
+                managerSO.FindProperty("playerShootable").objectReferenceValue = shootable;
+                managerSO.FindProperty("shotController").objectReferenceValue = shotController;
+                managerSO.ApplyModifiedProperties();
+            }
+        }
+
+        private static void CreateLight()
+        {
+            var lightObj = new GameObject("Directional Light");
+            var light = lightObj.AddComponent<Light>();
+            light.type = LightType.Directional;
+            light.color = Color.white;
+            light.intensity = 1f;
+            lightObj.transform.position = new Vector3(0, 10, 0);
+            lightObj.transform.rotation = Quaternion.Euler(50, -30, 0);
+        }
+
+        private static Material CreateMaterial(Color color)
+        {
+            var shader = Shader.Find("Universal Render Pipeline/Lit");
+            if (shader == null)
+            {
+                shader = Shader.Find("Standard");
+            }
+            var material = new Material(shader!);
+            material.color = color;
+            return material;
+        }
+
+        [MenuItem("WhatTheStrike/Create Stage Button Prefab")]
+        public static void CreateStageButtonPrefab()
+        {
+            // 保存先フォルダ
+            string folderPath = "Assets/Prefabs/Outgame";
+            if (!AssetDatabase.IsValidFolder(folderPath))
+            {
+                AssetDatabase.CreateFolder("Assets/Prefabs", "Outgame");
+            }
+
+            // ステージボタン作成
+            var buttonObj = new GameObject("StageButton");
+
+            // 円形のビジュアル（円柱で代用）
+            var visual = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+            visual.name = "Visual";
+            visual.transform.SetParent(buttonObj.transform);
+            visual.transform.localPosition = Vector3.zero;
+            visual.transform.localScale = new Vector3(1.5f, 0.1f, 1.5f);
+            visual.GetComponent<Renderer>().material = CreateMaterial(new Color(0.8f, 0.4f, 0.2f));
+
+            // コライダー削除（親にまとめる）
+            Object.DestroyImmediate(visual.GetComponent<Collider>());
+
+            // キャラクター画像表示用（SpriteRenderer）
+            var imageObj = new GameObject("CharacterImage");
+            imageObj.transform.SetParent(buttonObj.transform);
+            imageObj.transform.localPosition = new Vector3(0, 0.15f, 0);
+            imageObj.transform.localRotation = Quaternion.Euler(90, 0, 0);
+            imageObj.transform.localScale = new Vector3(1f, 1f, 1f);
+            var spriteRenderer = imageObj.AddComponent<SpriteRenderer>();
+
+            // 当たり判定（球）
+            var collider = buttonObj.AddComponent<SphereCollider>();
+            collider.radius = 0.8f;
+            collider.isTrigger = true;
+
+            // StageButton3Dコンポーネント
+            var stageButton = buttonObj.AddComponent<StageButton3D>();
+
+            // SerializedObjectで参照を設定
+            var buttonSO = new SerializedObject(stageButton);
+            buttonSO.FindProperty("characterImageRenderer").objectReferenceValue = spriteRenderer;
+            buttonSO.ApplyModifiedProperties();
+
+            // プレハブとして保存
+            string prefabPath = $"{folderPath}/StageButton.prefab";
+            PrefabUtility.SaveAsPrefabAsset(buttonObj, prefabPath);
+            Object.DestroyImmediate(buttonObj);
+
+            Debug.Log($"ステージボタンプレハブを作成しました: {prefabPath}");
+
+            // StageLayoutGeneratorにプレハブを設定
+            var layoutGenerator = Object.FindFirstObjectByType<StageLayoutGenerator>();
+            if (layoutGenerator != null)
+            {
+                var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+                var layoutSO = new SerializedObject(layoutGenerator);
+                layoutSO.FindProperty("stageButtonPrefab").objectReferenceValue = prefab;
+                layoutSO.ApplyModifiedProperties();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Editor/OutgameSceneBuilder.cs.meta
+++ b/Assets/Scripts/Editor/OutgameSceneBuilder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bdf7f07172df12e41b8a27fd1dd5c4ae

--- a/Assets/Scripts/Editor/StageRegistryEditor.cs
+++ b/Assets/Scripts/Editor/StageRegistryEditor.cs
@@ -1,0 +1,103 @@
+#nullable enable
+
+using UnityEngine;
+using UnityEditor;
+using System.IO;
+using System.Linq;
+using WhatTheStrike.Outgame;
+
+namespace WhatTheStrike.Editor
+{
+    /// <summary>
+    /// StageRegistry用のカスタムエディター
+    /// ステージシーンを自動収集する
+    /// </summary>
+    [CustomEditor(typeof(StageRegistry))]
+    public class StageRegistryEditor : UnityEditor.Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            DrawDefaultInspector();
+
+            EditorGUILayout.Space(10);
+
+            var registry = (StageRegistry)target;
+
+            if (GUILayout.Button("ステージシーンを自動収集", GUILayout.Height(30)))
+            {
+                CollectStageScenes(registry);
+            }
+
+            EditorGUILayout.Space(5);
+
+            if (GUILayout.Button("ステージリストをクリア", GUILayout.Height(25)))
+            {
+                if (EditorUtility.DisplayDialog("確認", "ステージリストをクリアしますか？", "はい", "いいえ"))
+                {
+                    ClearStages(registry);
+                }
+            }
+        }
+
+        private void CollectStageScenes(StageRegistry registry)
+        {
+            registry.ClearStages();
+
+            string folder = registry.StageSceneFolder;
+            string prefix = registry.StageScenePrefix;
+
+            // フォルダが存在しない場合は作成
+            if (!AssetDatabase.IsValidFolder(folder))
+            {
+                string[] pathParts = folder.Split('/');
+                string currentPath = pathParts[0];
+                for (int i = 1; i < pathParts.Length; i++)
+                {
+                    string nextPath = currentPath + "/" + pathParts[i];
+                    if (!AssetDatabase.IsValidFolder(nextPath))
+                    {
+                        AssetDatabase.CreateFolder(currentPath, pathParts[i]);
+                    }
+                    currentPath = nextPath;
+                }
+                Debug.Log($"ステージフォルダを作成しました: {folder}");
+            }
+
+            // シーンファイルを検索
+            var sceneGuids = AssetDatabase.FindAssets("t:Scene", new[] { folder });
+            var stageScenes = sceneGuids
+                .Select(guid => AssetDatabase.GUIDToAssetPath(guid))
+                .Where(path => Path.GetFileNameWithoutExtension(path).StartsWith(prefix))
+                .OrderBy(path => path)
+                .ToList();
+
+            foreach (var scenePath in stageScenes)
+            {
+                string sceneName = Path.GetFileNameWithoutExtension(scenePath);
+                string displayName = sceneName.Replace(prefix, "").Replace("_", " ");
+
+                // キャラクター画像を探す（同名のスプライトがあれば使用）
+                var spritePath = Path.ChangeExtension(scenePath, null) + ".png";
+                Sprite? sprite = AssetDatabase.LoadAssetAtPath<Sprite>(spritePath);
+
+                var stageInfo = new StageInfo(sceneName, displayName, sprite);
+                registry.AddStage(stageInfo);
+
+                Debug.Log($"ステージを登録: {sceneName}");
+            }
+
+            EditorUtility.SetDirty(registry);
+            AssetDatabase.SaveAssets();
+
+            Debug.Log($"ステージ収集完了: {stageScenes.Count}個のステージを登録しました");
+        }
+
+        private void ClearStages(StageRegistry registry)
+        {
+            registry.ClearStages();
+            EditorUtility.SetDirty(registry);
+            AssetDatabase.SaveAssets();
+            Debug.Log("ステージリストをクリアしました");
+        }
+    }
+}

--- a/Assets/Scripts/Editor/StageRegistryEditor.cs.meta
+++ b/Assets/Scripts/Editor/StageRegistryEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8374f874d707b114fb8164f4e4aa2851

--- a/Assets/Scripts/Outgame.meta
+++ b/Assets/Scripts/Outgame.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 487bb3c8f60f9ea4daf318aae3af8d83
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Outgame/OutgameManager.cs
+++ b/Assets/Scripts/Outgame/OutgameManager.cs
@@ -1,0 +1,257 @@
+#nullable enable
+
+using System;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace WhatTheStrike.Outgame
+{
+    /// <summary>
+    /// アウトゲームの状態
+    /// </summary>
+    public enum OutgameState
+    {
+        Initializing, // 初期化中
+        Ready,        // ショット可能
+        Moving,       // 移動中
+        StageSelect,  // ステージ選択中（遷移待ち）
+        Transitioning // シーン遷移中
+    }
+
+    /// <summary>
+    /// アウトゲーム管理
+    /// ステージ選択画面の制御
+    /// </summary>
+    public class OutgameManager : MonoBehaviour
+    {
+        [Header("参照")]
+        [SerializeField] private StageRegistry? stageRegistry;
+        [SerializeField] private StageLayoutGenerator? layoutGenerator;
+        [SerializeField] private Shootable3D? playerShootable;
+        [SerializeField] private Shot3DController? shotController;
+
+        [Header("シーン設定")]
+        [SerializeField] private string outgameSceneName = "StageSelect";
+
+        // 状態
+        private OutgameState _state = OutgameState.Initializing;
+        private StageButton3D? _lastHitStage;
+        private Vector3 _savedPlayerPosition;
+
+        // シングルトン
+        private static OutgameManager? _instance;
+        public static OutgameManager? Instance => _instance;
+
+        // プロパティ
+        public OutgameState State => _state;
+        public StageRegistry? Registry => stageRegistry;
+
+        // 静的データ（シーン間で保持）
+        private static string? _pendingSceneName;
+        private static Vector3 _returnPosition;
+        private static bool _shouldRestorePosition;
+
+        private void Awake()
+        {
+            if (_instance != null && _instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            _instance = this;
+        }
+
+        private void Start()
+        {
+            Initialize();
+        }
+
+        private void Initialize()
+        {
+            _state = OutgameState.Initializing;
+
+            // レイアウト生成
+            if (layoutGenerator != null)
+            {
+                layoutGenerator.GenerateLayout();
+
+                // ボタンイベント登録
+                foreach (var button in layoutGenerator.GeneratedButtons)
+                {
+                    button.OnActivated += OnStageButtonActivated;
+                }
+            }
+
+            // プレイヤー位置復元
+            if (playerShootable != null)
+            {
+                if (_shouldRestorePosition)
+                {
+                    playerShootable.transform.position = _returnPosition;
+                    _shouldRestorePosition = false;
+                }
+                else
+                {
+                    // 初期位置（ワールド下部中央）
+                    float startZ = layoutGenerator != null ? -layoutGenerator.WorldSizeZ / 2 + 1 : -4f;
+                    playerShootable.transform.position = new Vector3(0, 0.5f, startZ);
+                }
+
+                playerShootable.OnStopped += OnPlayerStopped;
+            }
+
+            // Shootable3Dイベント
+            if (playerShootable != null)
+            {
+                playerShootable.OnHitCollider += OnPlayerHitCollider;
+            }
+
+            _state = OutgameState.Ready;
+        }
+
+        private void OnPlayerHitCollider(Shootable3D shootable, Collider collider)
+        {
+            // ステージボタンに当たった場合
+            var stageButton = collider.GetComponent<StageButton3D>();
+            if (stageButton != null)
+            {
+                _lastHitStage = stageButton;
+            }
+        }
+
+        private void OnPlayerStopped(Shootable3D shootable)
+        {
+            // 最後に当たったステージに遷移
+            if (_lastHitStage != null)
+            {
+                // StageButton3Dのイベントで処理される
+            }
+            else
+            {
+                // ステージに当たらなかった場合
+                _state = OutgameState.Ready;
+                shootable.ResetState();
+            }
+
+            _lastHitStage = null;
+        }
+
+        private void OnStageButtonActivated(StageButton3D button, bool isExactStop)
+        {
+            if (_state == OutgameState.Transitioning) return;
+
+            // クリア済みステージはぴったり停止が必要
+            if (button.IsCleared && !isExactStop)
+            {
+                Debug.Log($"クリア済みステージ {button.SceneName} はぴったり停止が必要です");
+                _state = OutgameState.Ready;
+                playerShootable?.ResetState();
+                return;
+            }
+
+            Debug.Log($"ステージ選択: {button.SceneName}");
+            TransitionToStage(button.SceneName);
+        }
+
+        /// <summary>
+        /// ステージへ遷移
+        /// </summary>
+        private void TransitionToStage(string sceneName)
+        {
+            _state = OutgameState.Transitioning;
+
+            // 現在位置を保存
+            if (playerShootable != null)
+            {
+                _returnPosition = playerShootable.transform.position;
+                _shouldRestorePosition = true;
+            }
+
+            _pendingSceneName = sceneName;
+
+            // シーン遷移
+            SceneManager.LoadScene(sceneName);
+        }
+
+        /// <summary>
+        /// アウトゲームに戻る（インゲームから呼ばれる）
+        /// </summary>
+        public static void ReturnToOutgame(bool stageClear = false)
+        {
+            if (stageClear && _pendingSceneName != null)
+            {
+                // クリア情報は別途PlayerPrefsなどで保持
+                PlayerPrefs.SetInt($"StageClear_{_pendingSceneName}", 1);
+                PlayerPrefs.Save();
+            }
+
+            // アウトゲームシーンに戻る
+            var instance = Instance;
+            string outgameName = instance != null ? instance.outgameSceneName : "StageSelect";
+            SceneManager.LoadScene(outgameName);
+        }
+
+        /// <summary>
+        /// クリア状態をロード
+        /// </summary>
+        public void LoadClearedStates()
+        {
+            if (stageRegistry == null) return;
+
+            for (int i = 0; i < stageRegistry.StageCount; i++)
+            {
+                var stage = stageRegistry.GetStage(i);
+                if (stage != null)
+                {
+                    bool isCleared = PlayerPrefs.GetInt($"StageClear_{stage.SceneName}", 0) == 1;
+                    stage.IsCleared = isCleared;
+                }
+            }
+
+            layoutGenerator?.UpdateClearedStates();
+        }
+
+        /// <summary>
+        /// 全クリア状態をリセット
+        /// </summary>
+        public void ResetAllClearedStates()
+        {
+            if (stageRegistry == null) return;
+
+            for (int i = 0; i < stageRegistry.StageCount; i++)
+            {
+                var stage = stageRegistry.GetStage(i);
+                if (stage != null)
+                {
+                    PlayerPrefs.DeleteKey($"StageClear_{stage.SceneName}");
+                    stage.IsCleared = false;
+                }
+            }
+            PlayerPrefs.Save();
+
+            layoutGenerator?.UpdateClearedStates();
+        }
+
+        private void OnDestroy()
+        {
+            if (playerShootable != null)
+            {
+                playerShootable.OnStopped -= OnPlayerStopped;
+                playerShootable.OnHitCollider -= OnPlayerHitCollider;
+            }
+
+            if (layoutGenerator != null)
+            {
+                foreach (var button in layoutGenerator.GeneratedButtons)
+                {
+                    button.OnActivated -= OnStageButtonActivated;
+                }
+            }
+
+            if (_instance == this)
+            {
+                _instance = null;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Outgame/OutgameManager.cs.meta
+++ b/Assets/Scripts/Outgame/OutgameManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7d5bf18bf589a474cb500026d311b8e1

--- a/Assets/Scripts/Outgame/Shootable3D.cs
+++ b/Assets/Scripts/Outgame/Shootable3D.cs
@@ -1,0 +1,146 @@
+#nullable enable
+
+using System;
+using UnityEngine;
+
+namespace WhatTheStrike.Outgame
+{
+    /// <summary>
+    /// 3D版ショット対象物の状態
+    /// </summary>
+    public enum Shootable3DState
+    {
+        Ready,    // 発射可能
+        Moving,   // 移動中
+        Stopped   // 停止
+    }
+
+    /// <summary>
+    /// 3D版ショット対象物コンポーネント
+    /// アウトゲームのステージ選択で使用
+    /// </summary>
+    [RequireComponent(typeof(Rigidbody))]
+    [RequireComponent(typeof(Collider))]
+    public class Shootable3D : MonoBehaviour
+    {
+        [Header("物理設定")]
+        [SerializeField] private float baseSpeed = 5f;
+        [SerializeField] private float stopThreshold = 0.05f;
+        [SerializeField] private float friction = 0.98f;
+
+        [Header("パワー設定")]
+        [SerializeField] private float minPower = 1f;
+        [SerializeField] private float maxPower = 10f;
+        [SerializeField] private float chargeTimeForMax = 2f;
+
+        // 状態
+        private Shootable3DState _state = Shootable3DState.Ready;
+        private Rigidbody _rb = null!;
+        private float _chargeStartTime;
+        private float _currentChargePower;
+
+        // イベント
+        public event Action<Shootable3D>? OnStopped;
+        public event Action<Shootable3D, Collider>? OnHitCollider;
+
+        // プロパティ
+        public Shootable3DState State => _state;
+        public float CurrentChargePower => _currentChargePower;
+        public float ChargeProgress => Mathf.Clamp01((Time.time - _chargeStartTime) / chargeTimeForMax);
+        public float MinPower => minPower;
+        public float MaxPower => maxPower;
+
+        private void Awake()
+        {
+            _rb = GetComponent<Rigidbody>();
+            _rb.useGravity = false;
+            _rb.constraints = RigidbodyConstraints.FreezePositionY | RigidbodyConstraints.FreezeRotation;
+        }
+
+        /// <summary>
+        /// チャージ開始
+        /// </summary>
+        public void StartCharge()
+        {
+            if (_state != Shootable3DState.Ready) return;
+            _chargeStartTime = Time.time;
+            _currentChargePower = minPower;
+        }
+
+        /// <summary>
+        /// チャージ更新（引っ張り中毎フレーム呼ぶ）
+        /// </summary>
+        /// <param name="pullDistance">引っ張り距離（正規化済み 0-1）</param>
+        public void UpdateCharge(float pullDistance)
+        {
+            if (_state != Shootable3DState.Ready) return;
+
+            float chargeTime = Time.time - _chargeStartTime;
+            float timeProgress = Mathf.Clamp01(chargeTime / chargeTimeForMax);
+
+            // 時間と距離の両方でパワーを決定
+            float combinedProgress = Mathf.Max(timeProgress, pullDistance);
+            _currentChargePower = Mathf.Lerp(minPower, maxPower, combinedProgress);
+        }
+
+        /// <summary>
+        /// 発射
+        /// </summary>
+        /// <param name="direction">XZ平面上の方向</param>
+        public void Shoot(Vector3 direction)
+        {
+            if (_state != Shootable3DState.Ready) return;
+
+            _state = Shootable3DState.Moving;
+            Vector3 velocity = direction.normalized * _currentChargePower * baseSpeed;
+            velocity.y = 0; // Y方向は固定
+            _rb.linearVelocity = velocity;
+        }
+
+        /// <summary>
+        /// 即座に停止
+        /// </summary>
+        public void ForceStop()
+        {
+            _rb.linearVelocity = Vector3.zero;
+            _state = Shootable3DState.Stopped;
+            OnStopped?.Invoke(this);
+        }
+
+        /// <summary>
+        /// 状態をリセット
+        /// </summary>
+        public void ResetState()
+        {
+            _rb.linearVelocity = Vector3.zero;
+            _state = Shootable3DState.Ready;
+            _currentChargePower = minPower;
+        }
+
+        private void FixedUpdate()
+        {
+            if (_state != Shootable3DState.Moving) return;
+
+            // 摩擦適用
+            _rb.linearVelocity *= friction;
+
+            // 停止判定
+            if (_rb.linearVelocity.magnitude < stopThreshold)
+            {
+                _rb.linearVelocity = Vector3.zero;
+                _state = Shootable3DState.Stopped;
+                OnStopped?.Invoke(this);
+            }
+        }
+
+        private void OnCollisionEnter(Collision collision)
+        {
+            OnHitCollider?.Invoke(this, collision.collider);
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            OnHitCollider?.Invoke(this, other);
+        }
+    }
+}

--- a/Assets/Scripts/Outgame/Shootable3D.cs.meta
+++ b/Assets/Scripts/Outgame/Shootable3D.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 87c4f0a46229e804aaa27e21505d3937

--- a/Assets/Scripts/Outgame/Shot3DController.cs
+++ b/Assets/Scripts/Outgame/Shot3DController.cs
@@ -1,0 +1,213 @@
+#nullable enable
+
+using UnityEngine;
+
+namespace WhatTheStrike.Outgame
+{
+    /// <summary>
+    /// 3Dショット入力制御
+    /// アウトゲームのステージ選択で使用
+    /// </summary>
+    public class Shot3DController : MonoBehaviour
+    {
+        [Header("参照")]
+        [SerializeField] private Shootable3D? shootable;
+        [SerializeField] private LineRenderer? trajectoryLine;
+        [SerializeField] private Camera? shotCamera;
+
+        [Header("設定")]
+        [SerializeField] private float maxPullDistance = 3f;
+        [SerializeField] private LayerMask groundLayer;
+        [SerializeField] private float trajectoryLength = 5f;
+
+        // 状態
+        private bool _isDragging;
+        private Vector3 _dragStartPos;
+        private Vector3 _currentDragPos;
+        private Plane _groundPlane;
+
+        private void Start()
+        {
+            _groundPlane = new Plane(Vector3.up, Vector3.zero);
+
+            if (shotCamera == null)
+            {
+                shotCamera = Camera.main;
+            }
+
+            if (shootable != null)
+            {
+                shootable.OnStopped += OnShootableStopped;
+            }
+        }
+
+        private void Update()
+        {
+            if (shootable == null || shotCamera == null) return;
+            if (shootable.State != Shootable3DState.Ready) return;
+
+            HandleInput();
+            UpdateTrajectory();
+        }
+
+        private void HandleInput()
+        {
+            // タッチ/マウス開始
+            if (Input.GetMouseButtonDown(0))
+            {
+                Vector3? hitPos = GetGroundHitPosition();
+                if (hitPos.HasValue && IsShootableTouched(hitPos.Value))
+                {
+                    _isDragging = true;
+                    _dragStartPos = shootable!.transform.position;
+                    _currentDragPos = _dragStartPos;
+                    shootable.StartCharge();
+                }
+            }
+
+            // ドラッグ中
+            if (Input.GetMouseButton(0) && _isDragging)
+            {
+                Vector3? hitPos = GetGroundHitPosition();
+                if (hitPos.HasValue)
+                {
+                    _currentDragPos = hitPos.Value;
+                    float normalizedDistance = GetNormalizedPullDistance();
+                    shootable!.UpdateCharge(normalizedDistance);
+                }
+            }
+
+            // リリース
+            if (Input.GetMouseButtonUp(0) && _isDragging)
+            {
+                _isDragging = false;
+                ExecuteShot();
+                HideTrajectory();
+            }
+        }
+
+        private Vector3? GetGroundHitPosition()
+        {
+            if (shotCamera == null) return null;
+
+            Ray ray = shotCamera.ScreenPointToRay(Input.mousePosition);
+            if (_groundPlane.Raycast(ray, out float distance))
+            {
+                return ray.GetPoint(distance);
+            }
+            return null;
+        }
+
+        private bool IsShootableTouched(Vector3 worldPos)
+        {
+            if (shootable == null) return false;
+
+            var collider = shootable.GetComponent<Collider>();
+            if (collider != null)
+            {
+                // XZ平面での距離チェック
+                Vector3 shootablePos = shootable.transform.position;
+                Vector2 shootable2D = new(shootablePos.x, shootablePos.z);
+                Vector2 touch2D = new(worldPos.x, worldPos.z);
+                return Vector2.Distance(shootable2D, touch2D) < 1.5f;
+            }
+            return false;
+        }
+
+        private float GetNormalizedPullDistance()
+        {
+            Vector3 pullVector = _dragStartPos - _currentDragPos;
+            pullVector.y = 0;
+            return Mathf.Clamp01(pullVector.magnitude / maxPullDistance);
+        }
+
+        private Vector3 GetShotDirection()
+        {
+            Vector3 pullVector = _dragStartPos - _currentDragPos;
+            pullVector.y = 0;
+            return pullVector.normalized;
+        }
+
+        private void ExecuteShot()
+        {
+            if (shootable == null) return;
+
+            Vector3 pullVector = _dragStartPos - _currentDragPos;
+            pullVector.y = 0;
+
+            if (pullVector.magnitude < 0.1f) return;
+
+            shootable.Shoot(pullVector.normalized);
+        }
+
+        private void UpdateTrajectory()
+        {
+            if (trajectoryLine == null || shootable == null) return;
+
+            if (!_isDragging)
+            {
+                trajectoryLine.enabled = false;
+                return;
+            }
+
+            trajectoryLine.enabled = true;
+            Vector3 direction = GetShotDirection();
+            float power = shootable.CurrentChargePower;
+
+            // 軌道表示
+            trajectoryLine.positionCount = 2;
+            trajectoryLine.SetPosition(0, shootable.transform.position);
+            trajectoryLine.SetPosition(1, shootable.transform.position + direction * power * trajectoryLength * 0.1f);
+        }
+
+        private void HideTrajectory()
+        {
+            if (trajectoryLine != null)
+            {
+                trajectoryLine.enabled = false;
+            }
+        }
+
+        private void OnShootableStopped(Shootable3D shootable)
+        {
+            // OutgameManagerが処理するため、ここでは何もしない
+        }
+
+        /// <summary>
+        /// Shootableを設定
+        /// </summary>
+        public void SetShootable(Shootable3D newShootable)
+        {
+            if (shootable != null)
+            {
+                shootable.OnStopped -= OnShootableStopped;
+            }
+            shootable = newShootable;
+            if (shootable != null)
+            {
+                shootable.OnStopped += OnShootableStopped;
+            }
+        }
+
+        /// <summary>
+        /// 引っ張り情報を取得（UI用）
+        /// </summary>
+        public (Vector3 direction, float power, float normalizedDistance) GetPullInfo()
+        {
+            if (!_isDragging || shootable == null)
+            {
+                return (Vector3.zero, 0f, 0f);
+            }
+
+            return (GetShotDirection(), shootable.CurrentChargePower, GetNormalizedPullDistance());
+        }
+
+        private void OnDestroy()
+        {
+            if (shootable != null)
+            {
+                shootable.OnStopped -= OnShootableStopped;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Outgame/Shot3DController.cs.meta
+++ b/Assets/Scripts/Outgame/Shot3DController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c6f2ec91a6d29864ba1c5508d51b2bfe

--- a/Assets/Scripts/Outgame/StageButton3D.cs
+++ b/Assets/Scripts/Outgame/StageButton3D.cs
@@ -1,0 +1,169 @@
+#nullable enable
+
+using System;
+using UnityEngine;
+
+namespace WhatTheStrike.Outgame
+{
+    /// <summary>
+    /// 3Dステージボタン
+    /// Shootable3Dが範囲内で停止するとステージ遷移可能
+    /// </summary>
+    [RequireComponent(typeof(Collider))]
+    public class StageButton3D : MonoBehaviour
+    {
+        [Header("ステージ情報")]
+        [SerializeField] private string sceneName = "";
+        [SerializeField] private int stageIndex = -1;
+
+        [Header("ビジュアル")]
+        [SerializeField] private SpriteRenderer? characterImageRenderer;
+        [SerializeField] private Material? clearedMaterial;
+        [SerializeField] private Material? normalMaterial;
+
+        [Header("当たり判定")]
+        [SerializeField] private float exactStopRadius = 0.5f;
+
+        // 状態
+        private bool _isCleared;
+        private Collider _collider = null!;
+        private bool _shootableInRange;
+        private Shootable3D? _lastShootableInRange;
+
+        // イベント
+        public event Action<StageButton3D, bool>? OnActivated;
+
+        // プロパティ
+        public string SceneName => sceneName;
+        public int StageIndex => stageIndex;
+        public bool IsCleared
+        {
+            get => _isCleared;
+            set
+            {
+                _isCleared = value;
+                UpdateVisual();
+            }
+        }
+
+        private void Awake()
+        {
+            _collider = GetComponent<Collider>();
+            _collider.isTrigger = true;
+        }
+
+        private void Start()
+        {
+            UpdateVisual();
+        }
+
+        /// <summary>
+        /// ステージ情報を設定
+        /// </summary>
+        public void Setup(string sceneName, int stageIndex, Sprite? characterImage, bool isCleared)
+        {
+            this.sceneName = sceneName;
+            this.stageIndex = stageIndex;
+            _isCleared = isCleared;
+
+            if (characterImageRenderer != null && characterImage != null)
+            {
+                characterImageRenderer.sprite = characterImage;
+            }
+
+            UpdateVisual();
+        }
+
+        private void UpdateVisual()
+        {
+            // クリア済みは見た目を変更
+            if (characterImageRenderer != null)
+            {
+                var material = _isCleared ? clearedMaterial : normalMaterial;
+                if (material != null)
+                {
+                    characterImageRenderer.material = material;
+                }
+
+                // クリア済みは半透明に
+                Color color = characterImageRenderer.color;
+                color.a = _isCleared ? 0.5f : 1f;
+                characterImageRenderer.color = color;
+            }
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            var shootable = other.GetComponent<Shootable3D>();
+            if (shootable != null)
+            {
+                _shootableInRange = true;
+                _lastShootableInRange = shootable;
+                shootable.OnStopped += OnShootableStopped;
+            }
+        }
+
+        private void OnTriggerExit(Collider other)
+        {
+            var shootable = other.GetComponent<Shootable3D>();
+            if (shootable != null && shootable == _lastShootableInRange)
+            {
+                _shootableInRange = false;
+                shootable.OnStopped -= OnShootableStopped;
+                _lastShootableInRange = null;
+            }
+        }
+
+        private void OnShootableStopped(Shootable3D shootable)
+        {
+            shootable.OnStopped -= OnShootableStopped;
+
+            if (!_shootableInRange) return;
+
+            // クリア済みの場合はぴったり停止チェック
+            if (_isCleared)
+            {
+                float distance = Vector3.Distance(
+                    new Vector3(transform.position.x, 0, transform.position.z),
+                    new Vector3(shootable.transform.position.x, 0, shootable.transform.position.z)
+                );
+
+                if (distance <= exactStopRadius)
+                {
+                    OnActivated?.Invoke(this, true);
+                }
+            }
+            else
+            {
+                // 未クリアは範囲内停止でOK
+                OnActivated?.Invoke(this, false);
+            }
+
+            _shootableInRange = false;
+            _lastShootableInRange = null;
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            // 範囲を表示
+            Gizmos.color = _isCleared ? Color.gray : Color.green;
+            var collider = GetComponent<Collider>();
+            if (collider != null)
+            {
+                Gizmos.DrawWireCube(collider.bounds.center, collider.bounds.size);
+            }
+
+            // ぴったり停止範囲を表示（クリア済み用）
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawWireSphere(transform.position, exactStopRadius);
+        }
+
+        private void OnDestroy()
+        {
+            if (_lastShootableInRange != null)
+            {
+                _lastShootableInRange.OnStopped -= OnShootableStopped;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Outgame/StageButton3D.cs.meta
+++ b/Assets/Scripts/Outgame/StageButton3D.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2aa4433a7ab2c264b947543bbf376a63

--- a/Assets/Scripts/Outgame/StageInfo.cs
+++ b/Assets/Scripts/Outgame/StageInfo.cs
@@ -1,0 +1,35 @@
+#nullable enable
+
+using UnityEngine;
+
+namespace WhatTheStrike.Outgame
+{
+    /// <summary>
+    /// ステージ情報
+    /// </summary>
+    [System.Serializable]
+    public class StageInfo
+    {
+        [SerializeField] private string sceneName = "";
+        [SerializeField] private string displayName = "";
+        [SerializeField] private Sprite? characterImage;
+        [SerializeField] private bool isCleared;
+
+        public string SceneName => sceneName;
+        public string DisplayName => displayName;
+        public Sprite? CharacterImage => characterImage;
+        public bool IsCleared
+        {
+            get => isCleared;
+            set => isCleared = value;
+        }
+
+        public StageInfo(string sceneName, string displayName, Sprite? characterImage = null)
+        {
+            this.sceneName = sceneName;
+            this.displayName = displayName;
+            this.characterImage = characterImage;
+            this.isCleared = false;
+        }
+    }
+}

--- a/Assets/Scripts/Outgame/StageInfo.cs.meta
+++ b/Assets/Scripts/Outgame/StageInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: edbe49b411152fe409e1b3eacc1e46cd

--- a/Assets/Scripts/Outgame/StageLayoutGenerator.cs
+++ b/Assets/Scripts/Outgame/StageLayoutGenerator.cs
@@ -1,0 +1,176 @@
+#nullable enable
+
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace WhatTheStrike.Outgame
+{
+    /// <summary>
+    /// ステージ配置生成器
+    /// シード固定のランダム配置でステージボタンを配置する
+    /// </summary>
+    public class StageLayoutGenerator : MonoBehaviour
+    {
+        [Header("ワールド設定")]
+        [SerializeField] private float worldSizeX = 10f;
+        [SerializeField] private float worldSizeZ = 10f;
+        [SerializeField] private float stageButtonRadius = 0.8f;
+        [SerializeField] private float minDistanceBetweenStages = 2f;
+
+        [Header("配置設定")]
+        [SerializeField] private int layoutSeed = 12345;
+        [SerializeField] private int maxPlacementAttempts = 100;
+
+        [Header("プレハブ")]
+        [SerializeField] private GameObject? stageButtonPrefab;
+
+        [Header("参照")]
+        [SerializeField] private StageRegistry? stageRegistry;
+        [SerializeField] private Transform? stageButtonContainer;
+
+        // 生成されたボタン
+        private List<StageButton3D> _generatedButtons = new();
+
+        // プロパティ
+        public IReadOnlyList<StageButton3D> GeneratedButtons => _generatedButtons;
+        public float WorldSizeX => worldSizeX;
+        public float WorldSizeZ => worldSizeZ;
+
+        /// <summary>
+        /// ステージを配置
+        /// </summary>
+        public void GenerateLayout()
+        {
+            ClearLayout();
+
+            if (stageRegistry == null || stageButtonPrefab == null)
+            {
+                Debug.LogError("StageLayoutGenerator: StageRegistryまたはPrefabが設定されていません");
+                return;
+            }
+
+            // シード固定の乱数生成器
+            var random = new System.Random(layoutSeed);
+            var placedPositions = new List<Vector3>();
+
+            // プレイヤー開始位置を確保（中央下部）
+            Vector3 playerStartPos = new(0, 0, -worldSizeZ / 2 + 1);
+            placedPositions.Add(playerStartPos);
+
+            Transform container = stageButtonContainer != null ? stageButtonContainer : transform;
+
+            for (int i = 0; i < stageRegistry.StageCount; i++)
+            {
+                var stageInfo = stageRegistry.GetStage(i);
+                if (stageInfo == null) continue;
+
+                Vector3? position = FindValidPosition(random, placedPositions);
+                if (!position.HasValue)
+                {
+                    Debug.LogWarning($"StageLayoutGenerator: ステージ {stageInfo.SceneName} の配置位置が見つかりませんでした");
+                    continue;
+                }
+
+                // ステージボタン生成
+                var buttonObj = Instantiate(stageButtonPrefab, position.Value, Quaternion.identity, container);
+                buttonObj.name = $"StageButton_{stageInfo.SceneName}";
+
+                var button = buttonObj.GetComponent<StageButton3D>();
+                if (button != null)
+                {
+                    button.Setup(stageInfo.SceneName, i, stageInfo.CharacterImage, stageInfo.IsCleared);
+                    _generatedButtons.Add(button);
+                }
+
+                placedPositions.Add(position.Value);
+            }
+
+            Debug.Log($"StageLayoutGenerator: {_generatedButtons.Count}個のステージを配置しました");
+        }
+
+        /// <summary>
+        /// 有効な配置位置を探す
+        /// </summary>
+        private Vector3? FindValidPosition(System.Random random, List<Vector3> existingPositions)
+        {
+            for (int attempt = 0; attempt < maxPlacementAttempts; attempt++)
+            {
+                // ランダムな位置を生成
+                float x = (float)(random.NextDouble() * 2 - 1) * (worldSizeX / 2 - stageButtonRadius);
+                float z = (float)(random.NextDouble() * 2 - 1) * (worldSizeZ / 2 - stageButtonRadius);
+                Vector3 candidate = new(x, 0, z);
+
+                // 既存位置との距離チェック
+                bool isValid = true;
+                foreach (var pos in existingPositions)
+                {
+                    if (Vector3.Distance(candidate, pos) < minDistanceBetweenStages)
+                    {
+                        isValid = false;
+                        break;
+                    }
+                }
+
+                if (isValid)
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// レイアウトをクリア
+        /// </summary>
+        public void ClearLayout()
+        {
+            foreach (var button in _generatedButtons)
+            {
+                if (button != null)
+                {
+                    if (Application.isPlaying)
+                    {
+                        Destroy(button.gameObject);
+                    }
+                    else
+                    {
+                        DestroyImmediate(button.gameObject);
+                    }
+                }
+            }
+            _generatedButtons.Clear();
+        }
+
+        /// <summary>
+        /// ステージボタンのクリア状態を更新
+        /// </summary>
+        public void UpdateClearedStates()
+        {
+            if (stageRegistry == null) return;
+
+            foreach (var button in _generatedButtons)
+            {
+                var stageInfo = stageRegistry.GetStageBySceneName(button.SceneName);
+                if (stageInfo != null)
+                {
+                    button.IsCleared = stageInfo.IsCleared;
+                }
+            }
+        }
+
+        private void OnDrawGizmosSelected()
+        {
+            // ワールド範囲を表示
+            Gizmos.color = Color.cyan;
+            Vector3 center = transform.position;
+            Vector3 size = new(worldSizeX, 0.1f, worldSizeZ);
+            Gizmos.DrawWireCube(center, size);
+
+            // プレイヤー開始位置
+            Gizmos.color = Color.green;
+            Vector3 playerStart = center + new Vector3(0, 0, -worldSizeZ / 2 + 1);
+            Gizmos.DrawWireSphere(playerStart, 0.5f);
+        }
+    }
+}

--- a/Assets/Scripts/Outgame/StageLayoutGenerator.cs.meta
+++ b/Assets/Scripts/Outgame/StageLayoutGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cd0b49273b51548458f2f58ea0cf26b3

--- a/Assets/Scripts/Outgame/StageRegistry.cs
+++ b/Assets/Scripts/Outgame/StageRegistry.cs
@@ -1,0 +1,95 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace WhatTheStrike.Outgame
+{
+    /// <summary>
+    /// ステージ登録用ScriptableObject
+    /// エディターでステージシーンを自動収集する
+    /// </summary>
+    [CreateAssetMenu(fileName = "StageRegistry", menuName = "WhatTheStrike/Stage Registry")]
+    public class StageRegistry : ScriptableObject
+    {
+        [Header("ステージ設定")]
+        [SerializeField] private string stageScenePrefix = "Stage_";
+        [SerializeField] private string stageSceneFolder = "Assets/Scenes/Stages";
+
+        [Header("登録済みステージ")]
+        [SerializeField] private List<StageInfo> stages = new();
+
+        /// <summary>
+        /// 登録されているステージ一覧
+        /// </summary>
+        public IReadOnlyList<StageInfo> Stages => stages;
+
+        /// <summary>
+        /// ステージ数
+        /// </summary>
+        public int StageCount => stages.Count;
+
+        /// <summary>
+        /// ステージシーンのプレフィックス
+        /// </summary>
+        public string StageScenePrefix => stageScenePrefix;
+
+        /// <summary>
+        /// ステージシーンのフォルダパス
+        /// </summary>
+        public string StageSceneFolder => stageSceneFolder;
+
+        /// <summary>
+        /// ステージを取得
+        /// </summary>
+        public StageInfo? GetStage(int index)
+        {
+            if (index < 0 || index >= stages.Count) return null;
+            return stages[index];
+        }
+
+        /// <summary>
+        /// シーン名からステージを取得
+        /// </summary>
+        public StageInfo? GetStageBySceneName(string sceneName)
+        {
+            return stages.FirstOrDefault(s => s.SceneName == sceneName);
+        }
+
+        /// <summary>
+        /// ステージをクリア済みにする
+        /// </summary>
+        public void SetStageCleared(string sceneName, bool cleared = true)
+        {
+            var stage = GetStageBySceneName(sceneName);
+            if (stage != null)
+            {
+                stage.IsCleared = cleared;
+            }
+        }
+
+        /// <summary>
+        /// 全ステージクリア済みか
+        /// </summary>
+        public bool IsAllCleared => stages.All(s => s.IsCleared);
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// ステージリストをクリア（Editor用）
+        /// </summary>
+        public void ClearStages()
+        {
+            stages.Clear();
+        }
+
+        /// <summary>
+        /// ステージを追加（Editor用）
+        /// </summary>
+        public void AddStage(StageInfo stageInfo)
+        {
+            stages.Add(stageInfo);
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Outgame/StageRegistry.cs.meta
+++ b/Assets/Scripts/Outgame/StageRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 61a8995ac718a1f4697cc4ae398859ab


### PR DESCRIPTION
## Summary
- アウトゲーム（ステージ選択）システムを新規実装
- 3Dワールド上でボールを引っ張って発射し、ステージボタンに当てて遷移
- シード固定のランダム配置でプレイ毎の再現性を確保

## 新規ファイル

### Outgame層
| ファイル | 説明 |
|---------|------|
| `StageInfo.cs` | ステージ情報クラス |
| `StageRegistry.cs` | ステージ登録用ScriptableObject（自動収集対応） |
| `Shootable3D.cs` | 3D版ショット対象物（パワーチャージ対応） |
| `Shot3DController.cs` | 3D入力制御 |
| `StageButton3D.cs` | ステージボタン（クリア済み判定対応） |
| `StageLayoutGenerator.cs` | シード固定ランダム配置 |
| `OutgameManager.cs` | アウトゲーム全体管理・シーン遷移 |

### Editor拡張
| ファイル | 説明 |
|---------|------|
| `StageRegistryEditor.cs` | ステージ自動収集ボタン |
| `OutgameSceneBuilder.cs` | アウトゲームシーン自動生成メニュー |

## 機能詳細

### 1. シーン自動集積
- `Assets/Scenes/Stages/Stage_*.unity` を自動収集
- StageRegistryインスペクタの「ステージシーンを自動収集」ボタンで実行

### 2. ステージ配置
- 10m x 10m のワールドにシード固定配置
- 毎回同じ配置で再現性を確保

### 3. ショットパワー
- 引っ張り時間と距離でパワー決定
- `chargeTimeForMax`: 最大パワーまでの時間（2秒）

### 4. クリア済みステージ
- クリア済みは半透明表示
- ぴったり停止しないとプレイ不可（exactStopRadius内で判定）

### 5. シーン遷移・復帰
- ステージから戻ると同じ位置に出現
- `OutgameManager.ReturnToOutgame(stageClear)` で復帰

## 使い方
1. **メニュー** → `WhatTheStrike/Create Outgame Scene`
2. **メニュー** → `WhatTheStrike/Create Stage Button Prefab`
3. StageRegistry作成（`Create/WhatTheStrike/Stage Registry`）
4. StageLayoutGeneratorにRegistryとPrefabを設定
5. `Assets/Scenes/Stages/` に `Stage_xxx.unity` を追加
6. StageRegistryで「ステージシーンを自動収集」

## Test plan
- [ ] OutgameSceneBuilderでシーン生成確認
- [ ] StageButtonPrefab生成確認
- [ ] ボール引っ張り・発射動作確認
- [ ] ステージボタン衝突判定確認
- [ ] クリア済みステージのぴったり停止判定確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ステージ選択画面を追加しました。プレイヤーが3D環境内でステージボタンと対話できるようになります。
  * ステージのクリア状態を追跡・管理する機能を実装しました。
  * プレイヤーの位置を保存し、ゲーム終了後に復帰できる機能を追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->